### PR TITLE
Fix light mode code visibility in example values

### DIFF
--- a/src/assets/swagger-ui/swagger-ui-light.css
+++ b/src/assets/swagger-ui/swagger-ui-light.css
@@ -11,7 +11,14 @@ html {
 }
 
 .swagger-ui .opblock-body pre.microlight, .swagger-ui textarea.curl {
-    background: #f6f8fa;
+    background: #f6f8fa !important;
     border-radius: 4px;
-    color: #24292f;
+    color: #24292f !important;
+}
+
+/* Additional specific selectors for curl section */
+.swagger-ui textarea.curl {
+    background: #f6f8fa !important;
+    color: #24292f !important;
+    border: 1px solid #d0d7de !important;
 }

--- a/src/assets/swagger-ui/swagger-ui-light.css
+++ b/src/assets/swagger-ui/swagger-ui-light.css
@@ -9,3 +9,9 @@ html {
     box-sizing: border-box;
     filter: contrast(100%) brightness(100%) saturate(100%);
 }
+
+.swagger-ui .opblock-body pre.microlight, .swagger-ui textarea.curl {
+    background: #f6f8fa;
+    border-radius: 4px;
+    color: #24292f;
+}

--- a/src/assets/swagger-ui/swagger-ui-light.css
+++ b/src/assets/swagger-ui/swagger-ui-light.css
@@ -22,3 +22,11 @@ html {
     color: #24292f !important;
     border: 1px solid #d0d7de !important;
 }
+
+/* Fix syntax highlighting colors for light mode */
+.swagger-ui .opblock-body pre.microlight span {
+    text-shadow: none !important;
+    opacity: 1 !important;
+    color: #24292f !important;
+    font-style: normal !important;
+}


### PR DESCRIPTION
## Summary
- Fixed poor contrast issue in light mode where example value code blocks were hard to read
- Added proper styling for `.opblock-body pre.microlight` elements in light theme

## Changes
- Modified `swagger-ui-light.css` to include appropriate text color (`#24292f`) and background color (`#f6f8fa`) for code blocks
- Ensures better readability and accessibility in light mode

## Test plan
- [ ] Switch to light mode in OpenAPI view
- [ ] Open any OpenAPI specification with example values
- [ ] Verify that code blocks in example value sections are clearly readable
- [ ] Confirm the styling matches the overall light theme design

🤖 Generated with [Claude Code](https://claude.ai/code)